### PR TITLE
Rewrite infer script to be faster and only require images

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ The PGN is trained and evaluated on our [CIHP dataset](http://www.sysu-hcp.net/l
 
 We have released our trained models of PGN on CIHP dataset at [google drive](https://drive.google.com/open?id=1Mqpse5Gen4V4403wFEpv3w3JAsWw2uhk).
 
-### Inference
+### Simple Inference
+Use if you only want the segmented results from input images without evaluating the results.
+1. Download the pre-trained model and store in $HOME/checkpoint.
+2. Run `infer.py -i <input_dir> -o <output_dir>`.
+### Detailed Inference
 1. Download the pre-trained model and store in $HOME/checkpoint.
 2. Prepare the images and store in $HOME/datasets.
 3. Run test_pgn.py.

--- a/infer.py
+++ b/infer.py
@@ -1,0 +1,151 @@
+import os
+import scipy.io as sio
+import cv2
+import tensorflow as tf
+from PIL import Image
+from utils import *
+
+os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+
+N_CLASSES = 20
+DATA_DIR = './datasets/CIHP'
+LIST_PATH = './datasets/CIHP/list/val.txt'
+DATA_ID_LIST = './datasets/CIHP/list/val_id.txt'
+with open(DATA_ID_LIST, 'r') as f:
+    NUM_STEPS = len(f.readlines())
+RESTORE_FROM = './checkpoint/CIHP_pgn'
+
+
+def main():
+    """Create the model and start the evaluation process."""
+
+    # Create queue coordinator.
+    coord = tf.train.Coordinator()
+    # Load reader.
+    with tf.name_scope("create_inputs"):
+        reader = ImageReader(DATA_DIR, LIST_PATH, DATA_ID_LIST, None, False, False, False, coord)
+        image, label, edge_gt = reader.image, reader.label, reader.edge
+        image_rev = tf.reverse(image, tf.stack([1]))
+        image_list = reader.image_list
+
+    image_batch = tf.stack([image, image_rev])
+    label_batch = tf.expand_dims(label, dim=0) # Add one batch dimension.
+    edge_gt_batch = tf.expand_dims(edge_gt, dim=0)
+
+    # Create network.
+    net = PGNModel({'data': image_batch}, is_training=False, n_classes=N_CLASSES)
+
+    # parsing net
+    parsing_out1 = net.layers['parsing_fc']
+    parsing_out2 = net.layers['parsing_rf_fc']
+
+    # edge net
+    edge_out2 = net.layers['edge_rf_fc']
+
+    # combine resize
+    parsing_out1 = tf.image.resize_images(parsing_out1, tf.shape(image_batch)[1: 3, ])
+
+    edge_out2 = tf.image.resize_images(edge_out2, tf.shape(image_batch)[1: 3, ])
+
+    raw_output = tf.reduce_mean(tf.stack([parsing_out1, parsing_out2]), axis=0)
+    head_output, tail_output = tf.unstack(raw_output, num=2, axis=0)
+    tail_list = tf.unstack(tail_output, num=20, axis=2)
+    tail_list_rev = [None] * 20
+    for xx in range(14):
+        tail_list_rev[xx] = tail_list[xx]
+    tail_list_rev[14] = tail_list[15]
+    tail_list_rev[15] = tail_list[14]
+    tail_list_rev[16] = tail_list[17]
+    tail_list_rev[17] = tail_list[16]
+    tail_list_rev[18] = tail_list[19]
+    tail_list_rev[19] = tail_list[18]
+    tail_output_rev = tf.stack(tail_list_rev, axis=2)
+    tail_output_rev = tf.reverse(tail_output_rev, tf.stack([1]))
+
+    raw_output_all = tf.reduce_mean(tf.stack([head_output, tail_output_rev]), axis=0)
+    raw_output_all = tf.expand_dims(raw_output_all, dim=0)
+    pred_scores = tf.reduce_max(raw_output_all, axis=3)
+    raw_output_all = tf.argmax(raw_output_all, axis=3)
+    pred_all = tf.expand_dims(raw_output_all, dim=3) # Create 4-d tensor.
+
+    raw_edge = tf.reduce_mean(tf.stack([edge_out2]), axis=0)
+    head_output, tail_output = tf.unstack(raw_edge, num=2, axis=0)
+    tail_output_rev = tf.reverse(tail_output, tf.stack([1]))
+    raw_edge_all = tf.reduce_mean(tf.stack([head_output, tail_output_rev]), axis=0)
+    raw_edge_all = tf.expand_dims(raw_edge_all, dim=0)
+    pred_edge = tf.sigmoid(raw_edge_all)
+    res_edge = tf.cast(tf.greater(pred_edge, 0.5), tf.int32)
+
+    # prepare ground truth
+    preds = tf.reshape(pred_all, [-1,])
+    gt = tf.reshape(label_batch, [-1,])
+    weights = tf.cast(tf.less_equal(gt, N_CLASSES - 1), tf.int32) # Ignoring all labels greater than or equal to n_classes.
+    mIoU, update_op_iou = tf.contrib.metrics.streaming_mean_iou(preds, gt, num_classes=N_CLASSES, weights=weights)
+    macc, update_op_acc = tf.contrib.metrics.streaming_accuracy(preds, gt, weights=weights)
+
+    # precision and recall
+    recall, update_op_recall = tf.contrib.metrics.streaming_recall(res_edge, edge_gt_batch)
+    precision, update_op_precision = tf.contrib.metrics.streaming_precision(res_edge, edge_gt_batch)
+
+    update_op = tf.group(update_op_iou, update_op_acc, update_op_recall, update_op_precision)
+
+    # Which variables to load.
+    restore_var = tf.global_variables()
+    # Set up tf session and initialize variables.
+    config = tf.ConfigProto()
+    config.gpu_options.allow_growth = True
+    sess = tf.Session(config=config)
+    init = tf.global_variables_initializer()
+
+    sess.run(init)
+    sess.run(tf.local_variables_initializer())
+
+    # Load weights.
+    loader = tf.train.Saver(var_list=restore_var)
+    if RESTORE_FROM is not None:
+        if load(loader, sess, RESTORE_FROM):
+            print(" [*] Load SUCCESS")
+        else:
+            print(" [!] Load failed...")
+
+    # Start queue threads.
+    threads = tf.train.start_queue_runners(coord=coord, sess=sess)
+
+    # evaluate prosessing
+    parsing_dir = './output/cihp_parsing_maps'
+    if not os.path.exists(parsing_dir):
+        os.makedirs(parsing_dir)
+    edge_dir = './output/cihp_edge_maps'
+    if not os.path.exists(edge_dir):
+        os.makedirs(edge_dir)
+    # Iterate over training steps.
+    for step in range(NUM_STEPS):
+        parsing_, scores, edge_, _ = sess.run([pred_all, pred_scores, pred_edge, update_op])
+        if step % 100 == 0:
+            print('step {:d}'.format(step))
+            print(image_list[step])
+        img_split = image_list[step].split('/')
+        img_id = img_split[-1][:-4]
+
+        msk = decode_labels(parsing_, num_classes=N_CLASSES)
+        parsing_im = Image.fromarray(msk[0])
+        parsing_im.save('{}/{}_vis.png'.format(parsing_dir, img_id))
+        cv2.imwrite('{}/{}.png'.format(parsing_dir, img_id), parsing_[0,:,:,0])
+        sio.savemat('{}/{}.mat'.format(parsing_dir, img_id), {'data': scores[0,:,:]})
+
+        cv2.imwrite('{}/{}.png'.format(edge_dir, img_id), edge_[0,:,:,0] * 255)
+
+    res_mIou = mIoU.eval(session=sess)
+    res_macc = macc.eval(session=sess)
+    res_recall = recall.eval(session=sess)
+    res_precision = precision.eval(session=sess)
+    f1 = 2 * res_precision * res_recall / (res_precision + res_recall)
+    print('Mean IoU: {:.4f}, Mean Acc: {:.4f}'.format(res_mIou, res_macc))
+    print('Recall: {:.4f}, Precision: {:.4f}, F1 score: {:.4f}'.format(res_recall, res_precision, f1))
+
+    coord.request_stop()
+    coord.join(threads)
+
+
+if __name__ == '__main__':
+    main()

--- a/infer.py
+++ b/infer.py
@@ -16,8 +16,10 @@ def main(input_dir, output_dir, checkpoint_dir):
 
     # Load input
     input_files = sorted(glob(os.path.join(input_dir, '*')))
-
-    img = tf.io.decode_image(tf.read_file(tf.convert_to_tensor(input_files, dtype=tf.string)), channels=3)
+    input_files = tf.convert_to_tensor(input_files, dtype=tf.string)
+    input_queue = tf.train.slice_input_producer([input_files])
+    img_contents = tf.io.read_file(input_queue[0])
+    img = tf.io.decode_jpeg(img_contents, channels=3)
     img_r, img_g, img_b = tf.split(value=img, num_or_size_splits=3, axis=2)
     image = tf.cast(tf.concat([img_b, img_g, img_r], 2), dtype=tf.float32)
     # TODO: Subtract by mean (see image_reader)
@@ -110,16 +112,19 @@ if __name__ == '__main__':
     parser.add_argument(
         'input_dir',
         type=str,
+        default='datasets/images',
         help='Input images directory')
 
     parser.add_argument(
         'output_dir',
         type=str,
+        default='output',
         help='Output directory for segmented masks')
 
     parser.add_argument(
         'checkpoint_dir',
         type=str,
+        default='checkpoint/CIHP_pgn',
         help='Checkpoints directory')
 
     args = parser.parse_args()

--- a/infer.py
+++ b/infer.py
@@ -32,8 +32,9 @@ def main():
     label_batch = tf.expand_dims(label, dim=0) # Add one batch dimension.
     edge_gt_batch = tf.expand_dims(edge_gt, dim=0)
 
-    # Create network.
-    net = PGNModel({'data': image_batch}, is_training=False, n_classes=N_CLASSES)
+    # Create network
+    with tf.variable_scope('', reuse=False):
+        net = PGNModel({'data': image_batch}, is_training=False, n_classes=N_CLASSES)
 
     # parsing net
     parsing_out1 = net.layers['parsing_fc']
@@ -44,6 +45,7 @@ def main():
 
     # combine resize
     parsing_out1 = tf.image.resize_images(parsing_out1, tf.shape(image_batch)[1: 3, ])
+    parsing_out2 = tf.image.resize_images(parsing_out2, tf.shape(image_batch)[1: 3, ])
 
     edge_out2 = tf.image.resize_images(edge_out2, tf.shape(image_batch)[1: 3, ])
 

--- a/infer.py
+++ b/infer.py
@@ -16,8 +16,7 @@ def main(input_dir, output_dir, checkpoint_dir):
 
     # Load input
     input_files = sorted(glob(os.path.join(input_dir, '*')))
-    input_files = tf.convert_to_tensor(input_files, dtype=tf.string)
-    input_queue = tf.train.slice_input_producer([input_files])
+    input_queue = tf.train.slice_input_producer([tf.convert_to_tensor(input_files, dtype=tf.string)])
     img_contents = tf.io.read_file(input_queue[0])
     img = tf.io.decode_jpeg(img_contents, channels=3)
     img_r, img_g, img_b = tf.split(value=img, num_or_size_splits=3, axis=2)
@@ -110,19 +109,22 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        'input_dir',
+        '--input_dir',
+        '-i',
         type=str,
-        default='datasets/images',
+        default='datasets/CIHP/images',
         help='Input images directory')
 
     parser.add_argument(
-        'output_dir',
+        '--output_dir',
+        '-o',
         type=str,
         default='output',
         help='Output directory for segmented masks')
 
     parser.add_argument(
-        'checkpoint_dir',
+        '--checkpoint_dir',
+        '-c',
         type=str,
         default='checkpoint/CIHP_pgn',
         help='Checkpoints directory')

--- a/infer.py
+++ b/infer.py
@@ -8,6 +8,7 @@ from utils import *
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
 N_CLASSES = 20
+INPUT_RESIZE = 1024
 
 
 def main(input_dir, output_dir, checkpoint_dir):
@@ -19,6 +20,8 @@ def main(input_dir, output_dir, checkpoint_dir):
     input_queue = tf.train.slice_input_producer([tf.convert_to_tensor(input_files, dtype=tf.string)])
     img_contents = tf.io.read_file(input_queue[0])
     img = tf.io.decode_jpeg(img_contents, channels=3)
+    # Resize to prevent OOM
+    img = tf.image.resize(img, [INPUT_RESIZE, INPUT_RESIZE], preserve_aspect_ratio=True)
     img_r, img_g, img_b = tf.split(value=img, num_or_size_splits=3, axis=2)
     image = tf.cast(tf.concat([img_b, img_g, img_r], 2), dtype=tf.float32)
     # TODO: Subtract by mean (see image_reader)


### PR DESCRIPTION
The `test_pgn` script before required ground truths and ran a number of iterations for evaluation purposes. For simple inference, we don't need that.